### PR TITLE
Allow omit if no changes are made on update.

### DIFF
--- a/trigger.go
+++ b/trigger.go
@@ -54,8 +54,8 @@ type TriggerFunctions []TriggerFunction
 // https://www.zabbix.com/documentation/3.2/manual/api/reference/trigger/object
 type Trigger struct {
 	TriggerID   string `json:"triggerid,omitempty"`
-	Description string `json:"description"`
-	Expression  string `json:"expression"`
+	Description string `json:"description,omitempty"`
+	Expression  string `json:"expression,omitempty"`
 	Comments    string `json:"comments"`
 	//TemplateId  string    `json:"templateid"`
 	//Value ValueType `json:""`


### PR DESCRIPTION
If the trigger is inherited from template, the `Description` and `Expression` cannot be updated.
Therefore, allow `omitempty` to not update them.