### PR TITLE
Bump version: v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/claranet/go-zabbix-api
+module github.com/claranet/go-zabbix-api/v2
 
 go 1.18
 


### PR DESCRIPTION
Breaking change: https://github.com/elastic-infra/go-zabbix-api/pull/6